### PR TITLE
Turn into a pyolin program into a function

### DIFF
--- a/pyolin/ioformat.py
+++ b/pyolin/ioformat.py
@@ -407,7 +407,7 @@ PARSERS = {
 
 def create_parser(
     input_format: str, record_separator: str, field_separator: Optional[str]
-) -> Callable[[], AbstractParser]:
+) -> AbstractParser:
     """Creates a parser from the given `input_format`."""
     try:
         return PARSERS[input_format](record_separator, field_separator)

--- a/pyolin/ioformat.py
+++ b/pyolin/ioformat.py
@@ -406,7 +406,7 @@ PARSERS = {
 
 
 def create_parser(
-    input_format: str, record_separator: str, field_separator: str
+    input_format: str, record_separator: str, field_separator: Optional[str]
 ) -> Callable[[], AbstractParser]:
     """Creates a parser from the given `input_format`."""
     try:

--- a/pyolin/pyolin.py
+++ b/pyolin/pyolin.py
@@ -16,14 +16,14 @@ from typing import (
     Generic,
     Iterable,
     Optional,
+    Tuple,
     TypeVar,
     Union,
 )
 from hashbang import command, Argument
 
-from .ioformat import PARSERS, PRINTERS, Printer, create_parser, new_printer
+from .ioformat import PARSERS, PRINTERS, AbstractParser, Printer, create_parser, new_printer
 from .util import (
-    BoxedItem,
     LazyItem,
     Item,
     ItemDict,
@@ -31,7 +31,7 @@ from .util import (
     _UNDEFINED_,
     NoMoreRecords,
 )
-from .record import RecordSequence
+from .record import Header, RecordSequence
 from .parser import Prog
 
 
@@ -80,6 +80,41 @@ class RecordScoped(LazyItem, Generic[I]):
             raise NoMoreRecords() from exc
 
 
+class PyolinConfig:
+    _parser: Optional[AbstractParser] = None
+    _parser_frozen: bool = False
+    header: Optional[Header] = None
+
+    def __init__(self, printer: Printer, record_separator: str, field_separator: Optional[str], input_format: str):
+        self.printer = printer
+        self._record_separator = record_separator
+        self._field_separator = field_separator
+        self._input_format = input_format
+
+    @property
+    def parser(self) -> AbstractParser:
+        if not self._parser:
+            self._parser = self.new_parser(self._input_format)
+        return self._parser
+
+    @parser.setter
+    def parser(self, value):
+        if self._parser_frozen:
+            raise RuntimeError('Parsing already started, cannot set parser')
+        if isinstance(value, str):
+            self._parser = self.new_parser(value)
+        elif isinstance(value, AbstractParser):
+            self._parser = value
+        else:
+            raise TypeError(f'Expect `parser` to be an `AbstractParser`. Found `{value.__class__}` instead')
+
+    def new_parser(self, format: str) -> AbstractParser:
+        return create_parser(format, self._record_separator, self._field_separator)
+
+    def _freeze_parser(self) -> AbstractParser:
+        self._parser_frozen = True
+        return self.parser
+
 def _execute_internal(
     prog,
     *args,
@@ -88,24 +123,23 @@ def _execute_internal(
     record_separator="\n",
     input_format="auto",
     output_format="auto",
-):
+) -> Tuple[Any, PyolinConfig]:
     prog = Prog(prog)
 
-    def new_parser(input_format):
-        return create_parser(input_format, record_separator, field_separator)
-
-    parser_box = BoxedItem(lambda: new_parser(input_format))
+    try:
+        config = PyolinConfig(new_printer(output_format), record_separator, field_separator, input_format)
+    except KeyError:
+        raise ValueError(f'Unrecognized output format "{output_format}"') from None
 
     def gen_records(input_file: Optional[str]):
-        parser_box.frozen = True
-        parser = parser_box()
+        parser = config._freeze_parser()
         with get_io(input_file) as io_stream:
             for i, record in enumerate(parser.records(io_stream)):
                 record.set_num(i)
                 yield record
 
     def get_contents(input_file: Optional[str]) -> Union[str, bytes]:
-        parser_box.frozen = True
+        parser = config._freeze_parser()
         with get_io(input_file) as io_stream:
             contents = io_stream.read()
             try:
@@ -136,11 +170,7 @@ def _execute_internal(
         return LazyItem(func, on_accessed=lambda: set_scope("table"))
 
     record_var = RecordScoped(record_seq, on_accessed=lambda: set_scope("record"))
-    try:
-        printer = new_printer(output_format)
-    except KeyError:
-        # pylint:disable=raise-missing-from
-        raise ValueError(f'Unrecognized output format "{output_format}"')
+
     global_dict = ItemDict(
         {
             # Record scoped
@@ -158,17 +188,13 @@ def _execute_internal(
             "filename": input_,
             "_UNDEFINED_": _UNDEFINED_,
             "new_printer": new_printer,
-            "new_parser": new_parser,
+            "new_parser": config.new_parser,
             # Modules
-            "re": re,
             "pd": Item(lambda: importlib.import_module("pandas")),
             "np": Item(lambda: importlib.import_module("numpy")),
-            "csv": Item(lambda: importlib.import_module("csv")),
             "pyolin": Item(lambda: importlib.import_module("pyolin")),
-            # Writeable
-            "printer": printer,
-            "parser": parser_box,
-            "header": None,
+            # Config (which contains writable attributes)
+            "cfg": config,
         }
     )
 
@@ -178,14 +204,14 @@ def _execute_internal(
     try:
         result = prog.exec(global_dict)
     except NoMoreRecords:
-        return _UNDEFINED_, global_dict
+        return _UNDEFINED_, config
 
     if scope == "record":
         result = itertools.chain(
             (result,), (prog.exec(global_dict) for _ in record_var)
         )
 
-    return result, global_dict
+    return result, config
 
 
 def run(*args, **kwargs):
@@ -259,7 +285,7 @@ def _command_line(
         re – The regex module.
         pd – The pandas module, if installed.
     """
-    result, global_dict = _execute_internal(
+    result, config = _execute_internal(
         prog,
         *_REMAINDER_,
         input_=input_,
@@ -268,9 +294,9 @@ def _command_line(
         input_format=input_format,
         output_format=output_format,
     )
-    printer = global_dict["printer"]
+    printer = config.printer
     if not isinstance(printer, Printer):
         raise RuntimeError(
             f'printer must be an instance of Printer. Found "{printer!r}" instead'
         )
-    global_dict["printer"].print_result(result, header=global_dict.get("header"))
+    printer.print_result(result, header=config.header)

--- a/pyolin/test/test_pyolin.py
+++ b/pyolin/test/test_pyolin.py
@@ -2031,7 +2031,7 @@ Actual:
 
     def test_set_field_separator(self):
         self.assert_pyolin(
-            'parser.field_separator = ","; record',
+            'cfg.parser.field_separator = ","; record',
             """\
             | 0         | 1          | 2           | 3    | 4    | 5     | 6    | 7    | 8  |
             | --------- | ---------- | ----------- | ---- | ---- | ----- | ---- | ---- | -- |
@@ -2044,6 +2044,7 @@ Actual:
             | Heffalump | Harvey     | 632-79-9439 | 30.0 | 1.0  | 20.0  | 30.0 | 40.0 | C  |
             """,
             input_file="data_grades_simple_csv.csv",
+            input_format="tsv",  # Make sure we can change the field separator from "\t" to ","
         )
 
     def test_set_record_separator(self):

--- a/pyolin/test/test_pyolin.py
+++ b/pyolin/test/test_pyolin.py
@@ -170,7 +170,7 @@ Actual:
 
     def test_awk_output_format_field_separator(self):
         self.assert_pyolin(
-            'printer.field_separator = ","; fields',
+            'cfg.printer.field_separator = ","; fields',
             """\
             Bucks,Milwaukee,60,22,0.732
             Raptors,Toronto,58,24,0.707
@@ -183,7 +183,7 @@ Actual:
 
     def test_awk_output_format_record_separator(self):
         self.assert_pyolin(
-            'printer.record_separator = ";\\n"; fields',
+            'cfg.printer.record_separator = ";\\n"; fields',
             """\
             Bucks Milwaukee 60 22 0.732;
             Raptors Toronto 58 24 0.707;
@@ -536,7 +536,7 @@ Actual:
 
     def test_add_header(self):
         self.assert_pyolin(
-            'header = ("Team", "City", "Win", "Loss", "Winrate"); records',
+            'cfg.header = ("Team", "City", "Win", "Loss", "Winrate"); records',
             """\
             | Team    | City         | Win | Loss | Winrate |
             | ------- | ------------ | --- | ---- | ------- |
@@ -581,7 +581,7 @@ Actual:
 
     def test_streaming_stdin(self):
         with pyolin_popen(
-            "parser.has_header = False; line",
+            "cfg.parser.has_header = False; line",
             extra_args=["--input_format=awk", "--output_format=awk"],
         ) as proc:
             assert proc.stdin and proc.stdout
@@ -600,7 +600,7 @@ Actual:
 
     def test_closed_stdout(self):
         with pyolin_popen(
-            "parser.has_header = False; line",
+            "cfg.parser.has_header = False; line",
             extra_args=["--input_format=awk", "--output_format=awk"],
         ) as proc:
             assert proc.stdin and proc.stdout and proc.stderr
@@ -630,7 +630,7 @@ Actual:
 
     def test_streaming_slice(self):
         with pyolin_popen(
-            "parser.has_header = False; records[:2]",
+            "cfg.parser.has_header = False; records[:2]",
             extra_args=["--input_format=awk", "--output_format=awk"],
         ) as proc:
             assert proc.stdin and proc.stdout
@@ -646,7 +646,7 @@ Actual:
 
     def test_streaming_index(self):
         with pyolin_popen(
-            "parser.has_header = False; records[1].str",
+            "cfg.parser.has_header = False; records[1].str",
             extra_args=["--input_format=awk", "--output_format=awk"],
         ) as proc:
             assert proc.stdin and proc.stdout
@@ -661,7 +661,7 @@ Actual:
 
     def test_streaming_index_with_auto_parser(self):
         with pyolin_popen(
-            "parser.has_header = False; records[1].str",
+            "cfg.parser.has_header = False; records[1].str",
             extra_args=["--output_format=awk"],
         ) as proc:
             assert proc.stdin and proc.stdout
@@ -1066,7 +1066,7 @@ Actual:
 
     def test_record_separator_multiple_chars(self):
         self.assert_pyolin(
-            "parser.has_header=False; record",
+            "cfg.parser.has_header=False; record",
             """\
             | value    |
             | -------- |
@@ -1297,7 +1297,7 @@ Actual:
 
     def test_force_has_header(self):
         self.assert_pyolin(
-            "parser.has_header = True; (r[0], r[2], r[7]) for r in records",
+            "cfg.parser.has_header = True; (r[0], r[2], r[7]) for r in records",
             """\
             | Alfalfa   | 123-45-6789 | 49.0 |
             | --------- | ----------- | ---- |
@@ -1364,7 +1364,7 @@ Actual:
             run_cli("a = record[0]; b = records; b")
         self.assertEqual(
             "Cannot access both record scoped and table scoped variables",
-            str(context.exception.__cause__.__cause__), # type: ignore
+            str(context.exception.__cause__.__cause__),  # type: ignore
         )
 
     def test_access_table_and_record(self):
@@ -1372,7 +1372,7 @@ Actual:
             run_cli("a = records; b = record[0]; b")
         self.assertEqual(
             "Cannot access both record scoped and table scoped variables",
-            str(context.exception.__cause__.__cause__), # type: ignore
+            str(context.exception.__cause__.__cause__),  # type: ignore
         )
 
     def test_empty_record_scoped(self):
@@ -1418,7 +1418,7 @@ Actual:
 
     def test_csv_output_format_unix(self):
         self.assert_pyolin(
-            "printer.dialect = csv.unix_dialect; records",
+            "cfg.printer.dialect = csv.unix_dialect; records",
             """\
             "Bucks","Milwaukee","60","22","0.732"
             "Raptors","Toronto","58","24","0.707"
@@ -1431,12 +1431,12 @@ Actual:
 
     def test_csv_output_invalid_dialect(self):
         with self.assertRaises(ErrorWithStderr) as context:
-            run_cli('printer.dialect = "invalid"; records', output_format="csv")
+            run_cli('cfg.printer.dialect = "invalid"; records', output_format="csv")
         self.assertEqual('Unknown dialect "invalid"', str(context.exception.__cause__))
 
     def test_csv_output_format_delimiter(self):
         self.assert_pyolin(
-            'printer.delimiter = "^"; records',
+            'cfg.printer.delimiter = "^"; records',
             """\
             Bucks^Milwaukee^60^22^0.732\r
             Raptors^Toronto^58^24^0.707\r
@@ -1478,7 +1478,7 @@ Actual:
 
     def test_csv_output_with_header(self):
         self.assert_pyolin(
-            'printer.print_header = True; df[["Last name", "SSN", "Final"]]',
+            'cfg.printer.print_header = True; df[["Last name", "SSN", "Final"]]',
             """\
             Last name,SSN,Final\r
             Alfalfa,123-45-6789,49\r
@@ -1497,7 +1497,7 @@ Actual:
     def test_csv_output_with_header_function(self):
         def func():
             # pylint: disable=undefined-variable
-            printer.print_header = True  # type: ignore
+            cfg.printer.print_header = True  # type: ignore
             return df[["Last name", "SSN", "Final"]]  # type: ignore
             # pylint: enable=undefined-variable
 
@@ -1520,7 +1520,7 @@ Actual:
 
     def test_streaming_stdin_csv(self):
         with pyolin_popen(
-            "parser.has_header = False; record",
+            "cfg.parser.has_header = False; record",
             ["--output_format", "csv", "--input_format", "awk"],
         ) as proc:
             assert proc.stdin and proc.stdout
@@ -1537,7 +1537,7 @@ Actual:
 
     def test_numeric_header(self):
         self.assert_pyolin(
-            "printer.print_header = True; record[0],record[2],record[7]",
+            "cfg.printer.print_header = True; record[0],record[2],record[7]",
             """\
             0,1,2\r
             Alfalfa,123-45-6789,49.0\r
@@ -1707,7 +1707,7 @@ Actual:
 
     def test_json_output_with_manual_header(self):
         self.assert_pyolin(
-            "header = ['team', 'city', 'wins', 'loss', 'Win rate']; records[0]",
+            "cfg.header = ['team', 'city', 'wins', 'loss', 'Win rate']; records[0]",
             """\
             {
                 "team": "Bucks",
@@ -1891,7 +1891,7 @@ Actual:
 
     def test_set_printer(self):
         self.assert_pyolin(
-            'printer = new_printer("repr"); range(10)',
+            'cfg.printer = new_printer("repr"); range(10)',
             """\
             range(0, 10)
             """,
@@ -1899,7 +1899,7 @@ Actual:
 
     def test_printer_none(self):
         with self.assertRaises(ErrorWithStderr) as context:
-            run_cli("printer = None; 123")
+            run_cli("cfg.printer = None; 123")
         self.assertEqual(
             'printer must be an instance of Printer. Found "None" instead',
             str(context.exception.__cause__),
@@ -2017,7 +2017,9 @@ Actual:
 
         def format_exception_only(exc):
             if sys.version_info >= (3, 10):
-                return traceback.format_exception_only(exc)  # pylint:disable=no-value-for-parameter
+                return traceback.format_exception_only(
+                    exc
+                )  # pylint:disable=no-value-for-parameter
             else:
                 return traceback.format_exception_only(type(exc), exc)  # type: ignore
 
@@ -2046,7 +2048,7 @@ Actual:
 
     def test_set_record_separator(self):
         self.assert_pyolin(
-            'parser.record_separator = ","; record',
+            'cfg.parser.record_separator = ","; record',
             """\
             | value     |
             | --------- |
@@ -2068,9 +2070,9 @@ Actual:
             input_file="data_onerow.csv",
         )
 
-    def test_set_parser(self):
+    def test_set_parser_json(self):
         self.assert_pyolin(
-            'parser = new_parser("json"); df',
+            'cfg.parser = new_parser("json"); df',
             """\
             | color   | value |
             | ------- | ----- |
@@ -2087,10 +2089,10 @@ Actual:
 
     def test_set_parser_record(self):
         with self.assertRaises(ErrorWithStderr) as context:
-            run_cli("a = records[0]; parser = 123; 123")
+            run_cli("a = records[0]; cfg.parser = 123; cfg.header = (); 123")
         self.assertEqual(
-            "Cannot set parser after it has been used",
-            str(context.exception.__cause__.__cause__), # type: ignore
+            "Parsing already started, cannot set parser",
+            str(context.exception.__cause__.__cause__),  # type: ignore
         )
 
     def test_records_if_undefined(self):
@@ -2125,12 +2127,13 @@ Actual:
             run_cli("idontknowwhatisthis + 1")
         self.assertEqual(
             "name 'idontknowwhatisthis' is not defined",
-            str(context.exception.__cause__.__cause__), # type: ignore
+            str(context.exception.__cause__.__cause__),  # type: ignore
         )
 
     def test_record_first(self):
         self.assert_pyolin(
-            'if record.first: mysum = 0; header = ("sum", "value")\n'
+            "global mysum\n"
+            'if record.first: mysum = 0; cfg.header = ("sum", "value")\n'
             "mysum += record[2]\n"
             "mysum, record[2]",
             """\
@@ -2146,7 +2149,7 @@ Actual:
 
     def test_record_num(self):
         self.assert_pyolin(
-            'record.num',
+            "record.num",
             """\
             | value |
             | ----- |
@@ -2212,7 +2215,9 @@ Actual:
         Double semi-colon is treated as a newline
         """
         self.assert_pyolin(
-            "if record.first: sum = 0;; sum += record[2]; sum, record[2]",
+            # Alternative, record-scoped way to write
+            #   sum = 0; ((sum, record[2]) for record in records)
+            "global sum;; if record.first: sum = 0;; sum += record[2]; sum, record[2]",
             """\
             | 0   | 1  |
             | --- | -- |
@@ -2400,10 +2405,12 @@ Actual:
 
     def test_multiline_json_prog(self):
         self.assert_pyolin(
-            textwrap.dedent("""\
+            textwrap.dedent(
+                """\
             [
                 ['foo', ['a', 'b']], ['bar', ['c', 'd']]
-            ]"""),
+            ]"""
+            ),
             """\
             [
                 [
@@ -2428,7 +2435,7 @@ Actual:
             ]
             """,
             input_file="data_json_example.json",
-            output_format="json"
+            output_format="json",
         )
 
     def test_records_negative_index(self):

--- a/pyolin/test/test_pyolin.py
+++ b/pyolin/test/test_pyolin.py
@@ -27,7 +27,9 @@ def _test_file(file):
 
 def run_cli(prog, *, input_file="data_nba.txt", extra_args=(), **kwargs):
     with run_capturing_output(errmsg=f"Prog: {prog}") as output:
+        # pylint:disable=protected-access
         pyolin._command_line(prog, *extra_args, input_=_test_file(input_file), **kwargs)
+        # pylint:enable=protected-access
         return output
 
 
@@ -700,7 +702,7 @@ Actual:
 
     def test_percentage(self):
         self.assert_pyolin(
-            "(r[0], round(r[3] / sum(r[3] for r in records), 2)) " "for r in records",
+            "(r[0], round(r[3] / sum(r[3] for r in records), 2)) for r in records",
             """\
             | 0       | 1    |
             | ------- | ---- |
@@ -1362,7 +1364,7 @@ Actual:
             run_cli("a = record[0]; b = records; b")
         self.assertEqual(
             "Cannot access both record scoped and table scoped variables",
-            str(context.exception.__cause__.__cause__),
+            str(context.exception.__cause__.__cause__), # type: ignore
         )
 
     def test_access_table_and_record(self):
@@ -1370,7 +1372,7 @@ Actual:
             run_cli("a = records; b = record[0]; b")
         self.assertEqual(
             "Cannot access both record scoped and table scoped variables",
-            str(context.exception.__cause__.__cause__),
+            str(context.exception.__cause__.__cause__), # type: ignore
         )
 
     def test_empty_record_scoped(self):
@@ -1848,9 +1850,11 @@ Actual:
     def test_repr_printer_table(self):
         self.assert_pyolin(
             "records",
+            # pylint:disable=line-too-long
             """\
             [('Bucks', 'Milwaukee', '60', '22', '0.732'), ('Raptors', 'Toronto', '58', '24', '0.707'), ('76ers', 'Philadelphia', '51', '31', '0.622'), ('Celtics', 'Boston', '49', '33', '0.598'), ('Pacers', 'Indiana', '48', '34', '0.585')]
             """,
+            # pylint:enable=line-too-long
             output_format="repr",
         )
 
@@ -2013,7 +2017,7 @@ Actual:
 
         def format_exception_only(exc):
             if sys.version_info >= (3, 10):
-                return traceback.format_exception_only(exc)  # type: ignore
+                return traceback.format_exception_only(exc)  # pylint:disable=no-value-for-parameter
             else:
                 return traceback.format_exception_only(type(exc), exc)  # type: ignore
 
@@ -2086,7 +2090,7 @@ Actual:
             run_cli("a = records[0]; parser = 123; 123")
         self.assertEqual(
             "Cannot set parser after it has been used",
-            str(context.exception.__cause__.__cause__),
+            str(context.exception.__cause__.__cause__), # type: ignore
         )
 
     def test_records_if_undefined(self):
@@ -2121,7 +2125,7 @@ Actual:
             run_cli("idontknowwhatisthis + 1")
         self.assertEqual(
             "name 'idontknowwhatisthis' is not defined",
-            str(context.exception.__cause__.__cause__),
+            str(context.exception.__cause__.__cause__), # type: ignore
         )
 
     def test_record_first(self):

--- a/pyolin/util.py
+++ b/pyolin/util.py
@@ -20,6 +20,7 @@ from typing import (
     TypeVar,
     Union,
 )
+import typing
 
 
 def cache(func):
@@ -220,13 +221,13 @@ class LazyItem(Item[I]):
         self._cached = False
         self._on_accessed = on_accessed
 
-    def __call__(self, *arg, **kwargs):
+    def __call__(self, *arg, **kwargs) -> I:
         if not self._cached:
             self._val = super().__call__(*arg, **kwargs)
             if self._on_accessed:
                 self._on_accessed()
             self._cached = True
-        return self._val
+        return typing.cast(I, self._val)
 
 
 def peek_iter(iterator: Iterable[T], num: int) -> Tuple[Sequence[T], Iterable[T]]:

--- a/pyolin/util.py
+++ b/pyolin/util.py
@@ -137,21 +137,10 @@ class ItemDict(dict):
     """
 
     def __getitem__(self, key):
-        value = dict.__getitem__(self, key)
+        value = super().__getitem__(key)
         if isinstance(value, Item):
             return value()
         return value
-
-    def __setitem__(self, key, value):
-        try:
-            oldval = super().__getitem__(key)
-            if isinstance(oldval, SettableItem):
-                oldval.set(value)
-                return
-        except KeyError:
-            pass
-        debug(f"dict setting {key}={value}")
-        return super().__setitem__(key, value)
 
     def __missing__(self, key):
         try:
@@ -172,37 +161,6 @@ class Item(Generic[I]):
 
     def __call__(self, *arg, **kwargs) -> I:
         return self.func(*arg, **kwargs)
-
-
-class SettableItem(Item[I], metaclass=abc.ABCMeta):
-    """A settable item for use inside an ItemDict."""
-
-    @abc.abstractmethod
-    def set(self, value: I) -> None:
-        """Method to be called when the value of this item is set"""
-        raise NotImplementedError()
-
-
-class BoxedItem(SettableItem[I]):
-    """A SettableItem that just stores its value in a field, and can be frozen."""
-
-    def __init__(self, func: Callable[..., I]):
-        super().__init__(func)
-        self.value = None
-        self.frozen = False
-
-    def set(self, value: I) -> None:
-        debug("setting boxed value ", value)
-        if self.frozen:
-            raise RuntimeError("Cannot set parser after it has been used")
-        self.value = value
-
-    def __call__(self, *args, **kwargs) -> I:
-        assert not args and not kwargs
-        if self.value is not None:
-            return self.value
-        self.value = super().__call__()
-        return self.value
 
 
 class LazyItem(Item[I]):


### PR DESCRIPTION
This has 2 API-breaking implications:
1. New variables defined inside the program are no longer shared between
   invocations of record-scoped programs, which means `global foo` needs to
   be added at the start.

   e.g.
     `if record.first: sum = 0;; sum += record[0]; [sum]`
   now needs to be
     `global sum;; if record.first: sum = 0;; sum += record[0]; [sum]`

   (Of course, the better way to write that would be `sum(r[0] for r in records)`)

2. Programs are no longer allowed to implicitly set `parser`, `printer`, and `header`.
   Instead, those fields now need to be accessed from the new `cfg` object. This is
   done to reduce the reliance on hackery on the global dict passed to `eval` and `exec`.